### PR TITLE
Enable the extensions in certain filetypes

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -15,6 +15,17 @@
   ],
   "main": "src/extension.js",
   "contributes": {
+    "languages": [
+      {
+        "id": "auditor-allowed-extensions",
+        "extensions": [
+          ".go",
+          ".cpp",
+          ".c",
+          ".h"
+        ]
+      }
+    ],
     "commands": [
       {
         "command": "auditor.transform",


### PR DESCRIPTION
Only enable the extension in Golang and C/C++ codes