### PR TITLE
Auditor works on customizable extensions

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "auditor1",
+  "name": "auditor6",
+  "publisher": "Arash-Afshar",
   "displayName": "auditor",
   "description": "Track and manage audits/reviews of large code changes",
   "repository": "https://github.com/Arash-Afshar/auditor",
@@ -15,17 +16,6 @@
   ],
   "main": "src/extension.js",
   "contributes": {
-    "languages": [
-      {
-        "id": "auditor-allowed-extensions",
-        "extensions": [
-          ".go",
-          ".cpp",
-          ".c",
-          ".h"
-        ]
-      }
-    ],
     "commands": [
       {
         "command": "auditor.transform",
@@ -194,7 +184,18 @@
           "highContrast": "#FF000055"
         }
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Auditing Filetypes",
+      "properties": {
+        "auditor.auditingFiletypes": {
+          "type": "array",
+          "default": ["go"],
+          "description": "Only the codes in the listed filetypes will be colored and commented"
+        }
+      }
+    }
   },
   "scripts": {
     "lint": "eslint .",

--- a/extension/src/comments.js
+++ b/extension/src/comments.js
@@ -13,6 +13,8 @@ const newNoteComment = (id, body, mode, author, parent, contextValue) => {
 }
 
 async function commentHandler(context, endpoint) {
+    const auditingFiletypes = vscode.workspace.getConfiguration().get('auditor.auditingFiletypes');
+
     endpoint += 'comments';
     const commentController = vscode.comments.createCommentController(
         "audit.comment-controller",
@@ -23,8 +25,9 @@ async function commentHandler(context, endpoint) {
     // A `CommentingRangeProvider` controls where gutter decorations that allow adding comments are shown
     commentController.commentingRangeProvider = {
         provideCommentingRanges: (document) => {
-            const lineCount = document.lineCount;
-            return [new vscode.Range(0, 0, lineCount - 1, 0)];
+            if (auditingFiletypes.includes(document.languageId)) {
+                return [new vscode.Range(0, 0, document.lineCount - 1, 0)];
+            }
         },
     };
 

--- a/extension/src/comments.js
+++ b/extension/src/comments.js
@@ -230,7 +230,7 @@ async function commentHandler(context, endpoint) {
     let activeEditor = vscode.window.activeTextEditor;
     if (activeEditor) {
         const fileName = activeEditor.document.fileName;
-        if (fileName.endsWith("cpp") || fileName.endsWith("h") || fileName.endsWith("go")) {
+        if (auditingFiletypes.includes(activeEditor.document.languageId)) {
             if (!(fileName in initialized)) {
                 initialized[fileName] = true;
                 const comments = await getCommentsFromBackend(fileName);
@@ -242,7 +242,7 @@ async function commentHandler(context, endpoint) {
     vscode.window.onDidChangeActiveTextEditor(async (event) => {
         if (event != undefined) {
             const fileName = event.document.fileName;
-            if (fileName.endsWith("cpp") || fileName.endsWith("h") || fileName.endsWith("go")) {
+            if (auditingFiletypes.includes(event.document.languageId)) {
                 if (!(fileName in initialized)) {
                     initialized[fileName] = true;
                     const comments = await getCommentsFromBackend(fileName);

--- a/extension/src/linereviews.js
+++ b/extension/src/linereviews.js
@@ -3,6 +3,7 @@ const vscode = require("vscode");
 const fetch = require("node-fetch");
 
 function linereviewHandler(baseEndpoint) {
+    const auditingFiletypes = vscode.workspace.getConfiguration().get('auditor.auditingFiletypes');
     const reviewEndpoint = baseEndpoint + 'reviews';
     const transformReviewEndpoint = baseEndpoint + 'transform';
 
@@ -79,6 +80,9 @@ function linereviewHandler(baseEndpoint) {
 
     const showReviewState = ({ reviewed, modified, ignored }) => {
         let activeEditor = vscode.window.activeTextEditor;
+        if (!auditingFiletypes.includes(vscode.window.activeTextEditor.document.languageId)) {
+            return
+        }
 
         let _reviewed = new Set();
         let _modified = new Set();

--- a/extension/src/linereviews.js
+++ b/extension/src/linereviews.js
@@ -186,7 +186,7 @@ function linereviewHandler(baseEndpoint) {
     vscode.window.onDidChangeActiveTextEditor(async (event) => {
         if (event != undefined) {
             const fileName = event.document.fileName;
-            if (fileName.endsWith("cpp") || fileName.endsWith("h") || fileName.endsWith("go")) {
+            if (auditingFiletypes.includes(event.document.languageId)) {
                 const state = await getReviewState(fileName);
                 showReviewState(state);
             }
@@ -197,7 +197,7 @@ function linereviewHandler(baseEndpoint) {
     let activeEditor = vscode.window.activeTextEditor;
     if (activeEditor) {
         const fileName = activeEditor.document.fileName;
-        if (fileName.endsWith("cpp") || fileName.endsWith("h") || fileName.endsWith("go")) {
+        if (auditingFiletypes.includes(activeEditor.document.languageId)) {
             getReviewState(fileName).then((state) => {
                 showReviewState(state);
             });


### PR DESCRIPTION
Tested with default setting: only go codes are colored and can be commented
Tested with `"auditor.auditingFiletypes": ["c", "cpp"]`: only c/c++ codes are colored and can be commented