### PR TITLE
Clenup unnecessary variables and comments

### DIFF
--- a/web/src/app.rs
+++ b/web/src/app.rs
@@ -147,7 +147,7 @@ fn FileDetails(
     cx: Scope,
     reviewers: Vec<String>,
     full_file_name: String,
-    metadata: Option<Metadata>
+    metadata: Option<Metadata>,
 ) -> impl IntoView {
     let reviewer = metadata.unwrap().reviewer;
 
@@ -181,8 +181,6 @@ fn FileDetails(
 
         update_metadata_action.dispatch(request);
     };
-
-    // let reviewers = ["Yi-Hsiu", "Arash"]; // Hardcore the list of reviewers here.
 
     view! { cx,
         <form on:submit=on_submit>
@@ -511,7 +509,9 @@ fn Home(cx: Scope) -> impl IntoView {
                         Priority::Low => PriorityBF::LOW,
                         Priority::Ignore => PriorityBF::IGNORE,
                     };
-                    if reviewer == "Unassigned" && !filters().reviewer_unassigned {
+                    if (reviewer == "Unassigned" && !filters().reviewer_unassigned)
+                        || (reviewer != "Unassigned" && filters().reviewer_unassigned)
+                    {
                         return false;
                     }
                     if !filters().priority_mask.contains(priority) {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -122,11 +122,6 @@ pub struct Filters {
     pub reviewer_unassigned: bool,
 
     pub priority_mask: PriorityBF,
-    pub priority_unspecified: bool,
-    pub priority_high: bool,
-    pub priority_medium: bool,
-    pub priority_low: bool,
-    pub priority_ignore: bool,
 }
 
 impl Default for Filters {
@@ -140,14 +135,9 @@ impl Default for Filters {
             sort_by_reviewed: true,
             sort_by_name: false,
 
-            reviewer_unassigned: true,
+            reviewer_unassigned: false,
 
             priority_mask: PriorityBF::UNSPECIFIED | PriorityBF::HIGH | PriorityBF::MEDIUM | PriorityBF::LOW,
-            priority_unspecified: true,
-            priority_high: true,
-            priority_medium: true,
-            priority_low: true,
-            priority_ignore: false,
         }
     }
 }


### PR DESCRIPTION
Also changed the behavior of the "Unassigned filter". Now it either only shows unassigned ones or only shows assigned ones, but not both